### PR TITLE
mark the copr make_srpm git dir as safe

### DIFF
--- a/.copr/Makefile
+++ b/.copr/Makefile
@@ -1,7 +1,15 @@
+.PHONY: installdeps srpm git_config_pre
+
 installdeps:
 	dnf -y install git autoconf automake make gcc
 
-srpm: installdeps
+git_config_pre:
+	# From git 2.35.2 we need to mark temporary directory, where the project is cloned to, as safe, otherwise
+	# git commands won't work
+	$(eval REPO_DIR=$(shell pwd))
+	git config --global --add safe.directory ${REPO_DIR}
+
+srpm: installdeps git_config_pre
 	$(eval SUFFIX=$(shell sh -c " echo '.$$(date -u +%Y%m%d%H%M%S).git$$(git rev-parse --short HEAD)'"))
 	mkdir -p tmp.repos/SOURCES
 	autoreconf -ivf


### PR DESCRIPTION
See CVE-2022-24765

git >= 2.35.2 won't work on copr make_srpm builds without marking
the working directory as a safe.directory in git.

Signed-off-by: Sandro Bonazzola <sbonazzo@redhat.com>